### PR TITLE
import auth package only for DB related APIs

### DIFF
--- a/generator-jhipster-gomicro/generators/server/templates/controllers/eventcontroller.go
+++ b/generator-jhipster-gomicro/generators/server/templates/controllers/eventcontroller.go
@@ -1,7 +1,9 @@
 package controllers
 
 import (
+	<%_ if (postgresql||mongodb){  _%>
 	auth "<%= packageName %>/auth"
+	<%_ } _%>
 	"github.com/gorilla/mux"
 	"net/http"
 	"encoding/json"
@@ -14,7 +16,6 @@ import (
 	<%_ if (restClient){  _%>
 	"github.com/micro/micro/v3/service/logger"
 	<%_ } _%>
-
 )
 
 type EventController struct {


### PR DESCRIPTION
Auth is used for protecting APIs of event collection.
If DB is not connected to gomicro service, do not import auth package as DB APIs are not added.